### PR TITLE
Guard ledger transactions using cross-window connection

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 cookbook/package-lock.json
 codec/package-lock.json
 .idea
+settings.json

--- a/signing-providers/package-lock.json
+++ b/signing-providers/package-lock.json
@@ -1,17 +1,17 @@
 {
   "name": "examples",
-  "version": "0.0.0",
+  "version": "0.0.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "examples",
-      "version": "0.0.0",
+      "version": "0.0.1",
       "dependencies": {
         "@multiversx/sdk-core": "13.5.0",
         "@multiversx/sdk-dapp-utils": "0.1.0",
         "@multiversx/sdk-extension-provider": "3.0.0",
-        "@multiversx/sdk-hw-provider": "6.1.0",
+        "@multiversx/sdk-hw-provider": "7.0.0",
         "@multiversx/sdk-native-auth-client": "1.0.9",
         "@multiversx/sdk-network-providers": "2.7.1",
         "@multiversx/sdk-wallet": "4.5.1",
@@ -253,79 +253,197 @@
       "integrity": "sha512-D+r2B09vaRO06wfGoss+rNgwqWSoK0bCtsaJWzlD2hv1zxTtucqVtSztbRFypIqxWTCb3ix5Nh2dWHEJVTp2Xw=="
     },
     "node_modules/@ledgerhq/hw-transport": {
-      "version": "6.28.4",
-      "resolved": "https://registry.npmjs.org/@ledgerhq/hw-transport/-/hw-transport-6.28.4.tgz",
-      "integrity": "sha512-fB2H92YQjidmae2GFCmOGPwkZWk0lvTu0tlLlzfiY0wRheAG+DEgjnqhdU8wmydkPLIj0WUjRgldtnJtg/a2iQ==",
+      "version": "6.28.8",
+      "resolved": "https://registry.npmjs.org/@ledgerhq/hw-transport/-/hw-transport-6.28.8.tgz",
+      "integrity": "sha512-XxQVl4htd018u/M66r0iu5nlHi+J6QfdPsORzDF6N39jaz+tMqItb7tUlXM/isggcuS5lc7GJo7NOuJ8rvHZaQ==",
       "dependencies": {
-        "@ledgerhq/devices": "^8.0.3",
-        "@ledgerhq/errors": "^6.12.6",
+        "@ledgerhq/devices": "^8.0.7",
+        "@ledgerhq/errors": "^6.14.0",
         "events": "^3.3.0"
       }
     },
-    "node_modules/@ledgerhq/hw-transport-u2f": {
-      "version": "5.36.0-deprecated",
-      "resolved": "https://registry.npmjs.org/@ledgerhq/hw-transport-u2f/-/hw-transport-u2f-5.36.0-deprecated.tgz",
-      "integrity": "sha512-T/+mGHIiUK/ZQATad6DMDmobCMZ1mVST952009jKzhaE1Et2Uy2secU+QhRkx3BfEAkvwa0zSRSYCL9d20Iqjg==",
-      "deprecated": "@ledgerhq/hw-transport-u2f is deprecated. Please use @ledgerhq/hw-transport-webusb or @ledgerhq/hw-transport-webhid. https://github.com/LedgerHQ/ledgerjs/blob/master/docs/migrate_webusb.md",
+    "node_modules/@ledgerhq/hw-transport-web-ble": {
+      "version": "6.28.6",
+      "resolved": "https://registry.npmjs.org/@ledgerhq/hw-transport-web-ble/-/hw-transport-web-ble-6.28.6.tgz",
+      "integrity": "sha512-SsseU5T4ePhdvFdwUOsF207gyMgiHyymvRAV66/hpHCd0+m/81kV8nZneeD3Z1pG0XPG+tPlF90r7nLwtUoiXw==",
       "dependencies": {
-        "@ledgerhq/errors": "^5.34.0",
-        "@ledgerhq/hw-transport": "^5.34.0",
-        "@ledgerhq/logs": "^5.30.0",
-        "u2f-api": "0.2.7"
+        "@ledgerhq/devices": "^8.3.0",
+        "@ledgerhq/errors": "^6.16.4",
+        "@ledgerhq/hw-transport": "^6.30.6",
+        "@ledgerhq/logs": "^6.12.0",
+        "rxjs": "^7.8.1"
       }
     },
-    "node_modules/@ledgerhq/hw-transport-u2f/node_modules/@ledgerhq/devices": {
-      "version": "5.51.1",
-      "resolved": "https://registry.npmjs.org/@ledgerhq/devices/-/devices-5.51.1.tgz",
-      "integrity": "sha512-4w+P0VkbjzEXC7kv8T1GJ/9AVaP9I6uasMZ/JcdwZBS3qwvKo5A5z9uGhP5c7TvItzcmPb44b5Mw2kT+WjUuAA==",
+    "node_modules/@ledgerhq/hw-transport-web-ble/node_modules/@ledgerhq/devices": {
+      "version": "8.4.3",
+      "resolved": "https://registry.npmjs.org/@ledgerhq/devices/-/devices-8.4.3.tgz",
+      "integrity": "sha512-+ih+M27E6cm6DHrmw3GbS3mEaznCyFc0e62VdQux40XK2psgYhL2yBPftM4KCrBYm1UbHqXzqLN+Jb7rNIzsHg==",
       "dependencies": {
-        "@ledgerhq/errors": "^5.50.0",
-        "@ledgerhq/logs": "^5.50.0",
-        "rxjs": "6",
+        "@ledgerhq/errors": "^6.19.0",
+        "@ledgerhq/logs": "^6.12.0",
+        "rxjs": "^7.8.1",
         "semver": "^7.3.5"
       }
     },
-    "node_modules/@ledgerhq/hw-transport-u2f/node_modules/@ledgerhq/errors": {
-      "version": "5.50.0",
-      "resolved": "https://registry.npmjs.org/@ledgerhq/errors/-/errors-5.50.0.tgz",
-      "integrity": "sha512-gu6aJ/BHuRlpU7kgVpy2vcYk6atjB4iauP2ymF7Gk0ez0Y/6VSMVSJvubeEQN+IV60+OBK0JgeIZG7OiHaw8ow=="
+    "node_modules/@ledgerhq/hw-transport-web-ble/node_modules/@ledgerhq/errors": {
+      "version": "6.19.0",
+      "resolved": "https://registry.npmjs.org/@ledgerhq/errors/-/errors-6.19.0.tgz",
+      "integrity": "sha512-c3Jid7euMSnpHFp8H7iPtsmKDjwbTjlG46YKdw+RpCclsqtBx1uQDlYmcbP1Yv9201kVlUFUhhP4H623k8xzlQ=="
     },
-    "node_modules/@ledgerhq/hw-transport-u2f/node_modules/@ledgerhq/hw-transport": {
-      "version": "5.51.1",
-      "resolved": "https://registry.npmjs.org/@ledgerhq/hw-transport/-/hw-transport-5.51.1.tgz",
-      "integrity": "sha512-6wDYdbWrw9VwHIcoDnqWBaDFyviyjZWv6H9vz9Vyhe4Qd7TIFmbTl/eWs6hZvtZBza9K8y7zD8ChHwRI4s9tSw==",
+    "node_modules/@ledgerhq/hw-transport-web-ble/node_modules/@ledgerhq/hw-transport": {
+      "version": "6.31.3",
+      "resolved": "https://registry.npmjs.org/@ledgerhq/hw-transport/-/hw-transport-6.31.3.tgz",
+      "integrity": "sha512-rFplkHWF5NXtlYwAusqLlMu298NHtRD+2q/jrTYc//uu/xJO9LkDIgKid6IVF2+e1Wj7yX6YQVrU6L0Yu1ntEw==",
       "dependencies": {
-        "@ledgerhq/devices": "^5.51.1",
-        "@ledgerhq/errors": "^5.50.0",
+        "@ledgerhq/devices": "^8.4.3",
+        "@ledgerhq/errors": "^6.19.0",
+        "@ledgerhq/logs": "^6.12.0",
         "events": "^3.3.0"
       }
     },
-    "node_modules/@ledgerhq/hw-transport-u2f/node_modules/@ledgerhq/logs": {
-      "version": "5.50.0",
-      "resolved": "https://registry.npmjs.org/@ledgerhq/logs/-/logs-5.50.0.tgz",
-      "integrity": "sha512-swKHYCOZUGyVt4ge0u8a7AwNcA//h4nx5wIi0sruGye1IJ5Cva0GyK9L2/WdX+kWVTKp92ZiEo1df31lrWGPgA=="
+    "node_modules/@ledgerhq/hw-transport-web-ble/node_modules/rxjs": {
+      "version": "7.8.1",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.1.tgz",
+      "integrity": "sha512-AA3TVj+0A2iuIoQkWEK/tqFjBq2j+6PO6Y0zJcvzLAFhEFIO3HL0vls9hWLncZbAAbK0mar7oZ4V079I/qPMxg==",
+      "dependencies": {
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@ledgerhq/hw-transport-web-ble/node_modules/tslib": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.7.0.tgz",
+      "integrity": "sha512-gLXCKdN1/j47AiHiOkJN69hJmcbGTHI0ImLmbYLHykhgeN0jVGola9yVjFgzCUklsZQMW55o+dW7IXv3RCXDzA=="
     },
     "node_modules/@ledgerhq/hw-transport-webhid": {
-      "version": "6.27.15",
-      "resolved": "https://registry.npmjs.org/@ledgerhq/hw-transport-webhid/-/hw-transport-webhid-6.27.15.tgz",
-      "integrity": "sha512-xhtFy/SNttvBna8t1ZiP74K6Lj8uDhp0W+Zjvwz4IS6tS9gWZbKUB7scbrNrJep6Q77Of1bzDXrswyaoxFZrUg==",
+      "version": "6.28.6",
+      "resolved": "https://registry.npmjs.org/@ledgerhq/hw-transport-webhid/-/hw-transport-webhid-6.28.6.tgz",
+      "integrity": "sha512-npU1mgL97KovpTUgcdORoOZ7eVFgwCA7zt0MpgUGUMRNJWDgCFsJslx7KrVXlCGOg87gLfDojreIre502I5pYg==",
       "dependencies": {
-        "@ledgerhq/devices": "^8.0.3",
-        "@ledgerhq/errors": "^6.12.6",
-        "@ledgerhq/hw-transport": "^6.28.4",
-        "@ledgerhq/logs": "^6.10.1"
+        "@ledgerhq/devices": "^8.3.0",
+        "@ledgerhq/errors": "^6.16.4",
+        "@ledgerhq/hw-transport": "^6.30.6",
+        "@ledgerhq/logs": "^6.12.0"
       }
     },
-    "node_modules/@ledgerhq/hw-transport-webusb": {
-      "version": "6.27.15",
-      "resolved": "https://registry.npmjs.org/@ledgerhq/hw-transport-webusb/-/hw-transport-webusb-6.27.15.tgz",
-      "integrity": "sha512-XRteQmJMFbMETOwwwJrXhEvBEdu1DpuDQNI04bzMQE9p81rLjwd6pIhfP/W1O94av7Iq4kaatNsNpxkitmp59w==",
+    "node_modules/@ledgerhq/hw-transport-webhid/node_modules/@ledgerhq/devices": {
+      "version": "8.4.3",
+      "resolved": "https://registry.npmjs.org/@ledgerhq/devices/-/devices-8.4.3.tgz",
+      "integrity": "sha512-+ih+M27E6cm6DHrmw3GbS3mEaznCyFc0e62VdQux40XK2psgYhL2yBPftM4KCrBYm1UbHqXzqLN+Jb7rNIzsHg==",
       "dependencies": {
-        "@ledgerhq/devices": "^8.0.3",
-        "@ledgerhq/errors": "^6.12.6",
-        "@ledgerhq/hw-transport": "^6.28.4",
-        "@ledgerhq/logs": "^6.10.1"
+        "@ledgerhq/errors": "^6.19.0",
+        "@ledgerhq/logs": "^6.12.0",
+        "rxjs": "^7.8.1",
+        "semver": "^7.3.5"
       }
+    },
+    "node_modules/@ledgerhq/hw-transport-webhid/node_modules/@ledgerhq/errors": {
+      "version": "6.19.0",
+      "resolved": "https://registry.npmjs.org/@ledgerhq/errors/-/errors-6.19.0.tgz",
+      "integrity": "sha512-c3Jid7euMSnpHFp8H7iPtsmKDjwbTjlG46YKdw+RpCclsqtBx1uQDlYmcbP1Yv9201kVlUFUhhP4H623k8xzlQ=="
+    },
+    "node_modules/@ledgerhq/hw-transport-webhid/node_modules/@ledgerhq/hw-transport": {
+      "version": "6.31.3",
+      "resolved": "https://registry.npmjs.org/@ledgerhq/hw-transport/-/hw-transport-6.31.3.tgz",
+      "integrity": "sha512-rFplkHWF5NXtlYwAusqLlMu298NHtRD+2q/jrTYc//uu/xJO9LkDIgKid6IVF2+e1Wj7yX6YQVrU6L0Yu1ntEw==",
+      "dependencies": {
+        "@ledgerhq/devices": "^8.4.3",
+        "@ledgerhq/errors": "^6.19.0",
+        "@ledgerhq/logs": "^6.12.0",
+        "events": "^3.3.0"
+      }
+    },
+    "node_modules/@ledgerhq/hw-transport-webhid/node_modules/rxjs": {
+      "version": "7.8.1",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.1.tgz",
+      "integrity": "sha512-AA3TVj+0A2iuIoQkWEK/tqFjBq2j+6PO6Y0zJcvzLAFhEFIO3HL0vls9hWLncZbAAbK0mar7oZ4V079I/qPMxg==",
+      "dependencies": {
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@ledgerhq/hw-transport-webhid/node_modules/tslib": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.7.0.tgz",
+      "integrity": "sha512-gLXCKdN1/j47AiHiOkJN69hJmcbGTHI0ImLmbYLHykhgeN0jVGola9yVjFgzCUklsZQMW55o+dW7IXv3RCXDzA=="
+    },
+    "node_modules/@ledgerhq/hw-transport-webusb": {
+      "version": "6.28.6",
+      "resolved": "https://registry.npmjs.org/@ledgerhq/hw-transport-webusb/-/hw-transport-webusb-6.28.6.tgz",
+      "integrity": "sha512-rzICsvhcFcL4wSAvRPe+b9EEWB8cxj6yWy3FZdfs7ufi/0muNpFXWckWv1TC34em55sGXu2cMcwMKXg/O/Lc0Q==",
+      "dependencies": {
+        "@ledgerhq/devices": "^8.3.0",
+        "@ledgerhq/errors": "^6.16.4",
+        "@ledgerhq/hw-transport": "^6.30.6",
+        "@ledgerhq/logs": "^6.12.0"
+      }
+    },
+    "node_modules/@ledgerhq/hw-transport-webusb/node_modules/@ledgerhq/devices": {
+      "version": "8.4.3",
+      "resolved": "https://registry.npmjs.org/@ledgerhq/devices/-/devices-8.4.3.tgz",
+      "integrity": "sha512-+ih+M27E6cm6DHrmw3GbS3mEaznCyFc0e62VdQux40XK2psgYhL2yBPftM4KCrBYm1UbHqXzqLN+Jb7rNIzsHg==",
+      "dependencies": {
+        "@ledgerhq/errors": "^6.19.0",
+        "@ledgerhq/logs": "^6.12.0",
+        "rxjs": "^7.8.1",
+        "semver": "^7.3.5"
+      }
+    },
+    "node_modules/@ledgerhq/hw-transport-webusb/node_modules/@ledgerhq/errors": {
+      "version": "6.19.0",
+      "resolved": "https://registry.npmjs.org/@ledgerhq/errors/-/errors-6.19.0.tgz",
+      "integrity": "sha512-c3Jid7euMSnpHFp8H7iPtsmKDjwbTjlG46YKdw+RpCclsqtBx1uQDlYmcbP1Yv9201kVlUFUhhP4H623k8xzlQ=="
+    },
+    "node_modules/@ledgerhq/hw-transport-webusb/node_modules/@ledgerhq/hw-transport": {
+      "version": "6.31.3",
+      "resolved": "https://registry.npmjs.org/@ledgerhq/hw-transport/-/hw-transport-6.31.3.tgz",
+      "integrity": "sha512-rFplkHWF5NXtlYwAusqLlMu298NHtRD+2q/jrTYc//uu/xJO9LkDIgKid6IVF2+e1Wj7yX6YQVrU6L0Yu1ntEw==",
+      "dependencies": {
+        "@ledgerhq/devices": "^8.4.3",
+        "@ledgerhq/errors": "^6.19.0",
+        "@ledgerhq/logs": "^6.12.0",
+        "events": "^3.3.0"
+      }
+    },
+    "node_modules/@ledgerhq/hw-transport-webusb/node_modules/rxjs": {
+      "version": "7.8.1",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.1.tgz",
+      "integrity": "sha512-AA3TVj+0A2iuIoQkWEK/tqFjBq2j+6PO6Y0zJcvzLAFhEFIO3HL0vls9hWLncZbAAbK0mar7oZ4V079I/qPMxg==",
+      "dependencies": {
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@ledgerhq/hw-transport-webusb/node_modules/tslib": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.7.0.tgz",
+      "integrity": "sha512-gLXCKdN1/j47AiHiOkJN69hJmcbGTHI0ImLmbYLHykhgeN0jVGola9yVjFgzCUklsZQMW55o+dW7IXv3RCXDzA=="
+    },
+    "node_modules/@ledgerhq/hw-transport/node_modules/@ledgerhq/devices": {
+      "version": "8.4.3",
+      "resolved": "https://registry.npmjs.org/@ledgerhq/devices/-/devices-8.4.3.tgz",
+      "integrity": "sha512-+ih+M27E6cm6DHrmw3GbS3mEaznCyFc0e62VdQux40XK2psgYhL2yBPftM4KCrBYm1UbHqXzqLN+Jb7rNIzsHg==",
+      "dependencies": {
+        "@ledgerhq/errors": "^6.19.0",
+        "@ledgerhq/logs": "^6.12.0",
+        "rxjs": "^7.8.1",
+        "semver": "^7.3.5"
+      }
+    },
+    "node_modules/@ledgerhq/hw-transport/node_modules/@ledgerhq/errors": {
+      "version": "6.19.0",
+      "resolved": "https://registry.npmjs.org/@ledgerhq/errors/-/errors-6.19.0.tgz",
+      "integrity": "sha512-c3Jid7euMSnpHFp8H7iPtsmKDjwbTjlG46YKdw+RpCclsqtBx1uQDlYmcbP1Yv9201kVlUFUhhP4H623k8xzlQ=="
+    },
+    "node_modules/@ledgerhq/hw-transport/node_modules/rxjs": {
+      "version": "7.8.1",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.1.tgz",
+      "integrity": "sha512-AA3TVj+0A2iuIoQkWEK/tqFjBq2j+6PO6Y0zJcvzLAFhEFIO3HL0vls9hWLncZbAAbK0mar7oZ4V079I/qPMxg==",
+      "dependencies": {
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@ledgerhq/hw-transport/node_modules/tslib": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.7.0.tgz",
+      "integrity": "sha512-gLXCKdN1/j47AiHiOkJN69hJmcbGTHI0ImLmbYLHykhgeN0jVGola9yVjFgzCUklsZQMW55o+dW7IXv3RCXDzA=="
     },
     "node_modules/@ledgerhq/logs": {
       "version": "6.12.0",
@@ -374,21 +492,21 @@
       }
     },
     "node_modules/@multiversx/sdk-hw-provider": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/@multiversx/sdk-hw-provider/-/sdk-hw-provider-6.1.0.tgz",
-      "integrity": "sha512-9iQ2k6y80/OJ+30ETPNpN5t+pgI1mbBGGN60xaB7yH9E6eIlJuwZi/XIApMHKmitMdu7pe4+6Ig9FQHQ6YMxGA==",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@multiversx/sdk-hw-provider/-/sdk-hw-provider-7.0.0.tgz",
+      "integrity": "sha512-ZRGp5q985v5wvjnSZw+uvEXKGwe5YORuULhYMVoh63cPtGhyHIxl7H9D190KtSV0/LJfTcVUDDrtKoepOoKuVA==",
       "dependencies": {
         "@ledgerhq/devices": "8.0.3",
         "@ledgerhq/errors": "6.12.6",
-        "@ledgerhq/hw-transport": "6.28.4",
-        "@ledgerhq/hw-transport-u2f": "5.36.0-deprecated",
-        "@ledgerhq/hw-transport-webhid": "6.27.15",
-        "@ledgerhq/hw-transport-webusb": "6.27.15",
+        "@ledgerhq/hw-transport": "6.28.8",
+        "@ledgerhq/hw-transport-web-ble": "6.28.6",
+        "@ledgerhq/hw-transport-webhid": "6.28.6",
+        "@ledgerhq/hw-transport-webusb": "6.28.6",
         "buffer": "6.0.3",
         "platform": "1.3.6"
       },
       "peerDependencies": {
-        "@multiversx/sdk-core": ">= 12.1.0"
+        "@multiversx/sdk-core": ">= 13.5.0"
       }
     },
     "node_modules/@multiversx/sdk-native-auth-client": {
@@ -3354,17 +3472,6 @@
       "integrity": "sha512-lcHwpNoggQTObv5apGNCTdJrO69eHOZMi4BNC+rTLER8iHAqGrUVeLh/irVIM7zTw2bOXA8T6uNPeujwOLg/2Q==",
       "peer": true
     },
-    "node_modules/lru-cache": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-      "dependencies": {
-        "yallist": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/md5.js": {
       "version": "1.3.5",
       "resolved": "https://registry.npmjs.org/md5.js/-/md5.js-1.3.5.tgz",
@@ -4140,12 +4247,9 @@
       "integrity": "sha512-1CdSqHQowJBnMAFyPEBRfqag/YP9OF394FV+4YREIJX4ljD7OxvQRDayyoyyCk+senRjSkP6VnUNQmVQqB6g7w=="
     },
     "node_modules/semver": {
-      "version": "7.5.3",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.3.tgz",
-      "integrity": "sha512-QBlUtyVk/5EeHbi7X0fw6liDZc7BBmEaSYn01fMU1OUYbf6GPsbTtd8WmnqbI20SeycoHSeiybkE/q1Q+qlThQ==",
-      "dependencies": {
-        "lru-cache": "^6.0.0"
-      },
+      "version": "7.6.3",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
+      "integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
       "bin": {
         "semver": "bin/semver.js"
       },
@@ -4505,11 +4609,6 @@
       "engines": {
         "node": ">=4.2.0"
       }
-    },
-    "node_modules/u2f-api": {
-      "version": "0.2.7",
-      "resolved": "https://registry.npmjs.org/u2f-api/-/u2f-api-0.2.7.tgz",
-      "integrity": "sha512-fqLNg8vpvLOD5J/z4B6wpPg4Lvowz1nJ9xdHcCzdUPKcFE/qNCceV2gNZxSJd5vhAZemHr/K/hbzVA0zxB5mkg=="
     },
     "node_modules/ufo": {
       "version": "1.5.4",
@@ -4916,11 +5015,6 @@
       "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.3.tgz",
       "integrity": "sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ=="
     },
-    "node_modules/yallist": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
-    },
     "node_modules/yargs": {
       "version": "15.4.1",
       "resolved": "https://registry.npmjs.org/yargs/-/yargs-15.4.1.tgz",
@@ -5133,79 +5227,204 @@
       "integrity": "sha512-D+r2B09vaRO06wfGoss+rNgwqWSoK0bCtsaJWzlD2hv1zxTtucqVtSztbRFypIqxWTCb3ix5Nh2dWHEJVTp2Xw=="
     },
     "@ledgerhq/hw-transport": {
-      "version": "6.28.4",
-      "resolved": "https://registry.npmjs.org/@ledgerhq/hw-transport/-/hw-transport-6.28.4.tgz",
-      "integrity": "sha512-fB2H92YQjidmae2GFCmOGPwkZWk0lvTu0tlLlzfiY0wRheAG+DEgjnqhdU8wmydkPLIj0WUjRgldtnJtg/a2iQ==",
+      "version": "6.28.8",
+      "resolved": "https://registry.npmjs.org/@ledgerhq/hw-transport/-/hw-transport-6.28.8.tgz",
+      "integrity": "sha512-XxQVl4htd018u/M66r0iu5nlHi+J6QfdPsORzDF6N39jaz+tMqItb7tUlXM/isggcuS5lc7GJo7NOuJ8rvHZaQ==",
       "requires": {
-        "@ledgerhq/devices": "^8.0.3",
-        "@ledgerhq/errors": "^6.12.6",
+        "@ledgerhq/devices": "^8.0.7",
+        "@ledgerhq/errors": "^6.14.0",
         "events": "^3.3.0"
-      }
-    },
-    "@ledgerhq/hw-transport-u2f": {
-      "version": "5.36.0-deprecated",
-      "resolved": "https://registry.npmjs.org/@ledgerhq/hw-transport-u2f/-/hw-transport-u2f-5.36.0-deprecated.tgz",
-      "integrity": "sha512-T/+mGHIiUK/ZQATad6DMDmobCMZ1mVST952009jKzhaE1Et2Uy2secU+QhRkx3BfEAkvwa0zSRSYCL9d20Iqjg==",
-      "requires": {
-        "@ledgerhq/errors": "^5.34.0",
-        "@ledgerhq/hw-transport": "^5.34.0",
-        "@ledgerhq/logs": "^5.30.0",
-        "u2f-api": "0.2.7"
       },
       "dependencies": {
         "@ledgerhq/devices": {
-          "version": "5.51.1",
-          "resolved": "https://registry.npmjs.org/@ledgerhq/devices/-/devices-5.51.1.tgz",
-          "integrity": "sha512-4w+P0VkbjzEXC7kv8T1GJ/9AVaP9I6uasMZ/JcdwZBS3qwvKo5A5z9uGhP5c7TvItzcmPb44b5Mw2kT+WjUuAA==",
+          "version": "8.4.3",
+          "resolved": "https://registry.npmjs.org/@ledgerhq/devices/-/devices-8.4.3.tgz",
+          "integrity": "sha512-+ih+M27E6cm6DHrmw3GbS3mEaznCyFc0e62VdQux40XK2psgYhL2yBPftM4KCrBYm1UbHqXzqLN+Jb7rNIzsHg==",
           "requires": {
-            "@ledgerhq/errors": "^5.50.0",
-            "@ledgerhq/logs": "^5.50.0",
-            "rxjs": "6",
+            "@ledgerhq/errors": "^6.19.0",
+            "@ledgerhq/logs": "^6.12.0",
+            "rxjs": "^7.8.1",
             "semver": "^7.3.5"
           }
         },
         "@ledgerhq/errors": {
-          "version": "5.50.0",
-          "resolved": "https://registry.npmjs.org/@ledgerhq/errors/-/errors-5.50.0.tgz",
-          "integrity": "sha512-gu6aJ/BHuRlpU7kgVpy2vcYk6atjB4iauP2ymF7Gk0ez0Y/6VSMVSJvubeEQN+IV60+OBK0JgeIZG7OiHaw8ow=="
+          "version": "6.19.0",
+          "resolved": "https://registry.npmjs.org/@ledgerhq/errors/-/errors-6.19.0.tgz",
+          "integrity": "sha512-c3Jid7euMSnpHFp8H7iPtsmKDjwbTjlG46YKdw+RpCclsqtBx1uQDlYmcbP1Yv9201kVlUFUhhP4H623k8xzlQ=="
+        },
+        "rxjs": {
+          "version": "7.8.1",
+          "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.1.tgz",
+          "integrity": "sha512-AA3TVj+0A2iuIoQkWEK/tqFjBq2j+6PO6Y0zJcvzLAFhEFIO3HL0vls9hWLncZbAAbK0mar7oZ4V079I/qPMxg==",
+          "requires": {
+            "tslib": "^2.1.0"
+          }
+        },
+        "tslib": {
+          "version": "2.7.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.7.0.tgz",
+          "integrity": "sha512-gLXCKdN1/j47AiHiOkJN69hJmcbGTHI0ImLmbYLHykhgeN0jVGola9yVjFgzCUklsZQMW55o+dW7IXv3RCXDzA=="
+        }
+      }
+    },
+    "@ledgerhq/hw-transport-web-ble": {
+      "version": "6.28.6",
+      "resolved": "https://registry.npmjs.org/@ledgerhq/hw-transport-web-ble/-/hw-transport-web-ble-6.28.6.tgz",
+      "integrity": "sha512-SsseU5T4ePhdvFdwUOsF207gyMgiHyymvRAV66/hpHCd0+m/81kV8nZneeD3Z1pG0XPG+tPlF90r7nLwtUoiXw==",
+      "requires": {
+        "@ledgerhq/devices": "^8.3.0",
+        "@ledgerhq/errors": "^6.16.4",
+        "@ledgerhq/hw-transport": "^6.30.6",
+        "@ledgerhq/logs": "^6.12.0",
+        "rxjs": "^7.8.1"
+      },
+      "dependencies": {
+        "@ledgerhq/devices": {
+          "version": "8.4.3",
+          "resolved": "https://registry.npmjs.org/@ledgerhq/devices/-/devices-8.4.3.tgz",
+          "integrity": "sha512-+ih+M27E6cm6DHrmw3GbS3mEaznCyFc0e62VdQux40XK2psgYhL2yBPftM4KCrBYm1UbHqXzqLN+Jb7rNIzsHg==",
+          "requires": {
+            "@ledgerhq/errors": "^6.19.0",
+            "@ledgerhq/logs": "^6.12.0",
+            "rxjs": "^7.8.1",
+            "semver": "^7.3.5"
+          }
+        },
+        "@ledgerhq/errors": {
+          "version": "6.19.0",
+          "resolved": "https://registry.npmjs.org/@ledgerhq/errors/-/errors-6.19.0.tgz",
+          "integrity": "sha512-c3Jid7euMSnpHFp8H7iPtsmKDjwbTjlG46YKdw+RpCclsqtBx1uQDlYmcbP1Yv9201kVlUFUhhP4H623k8xzlQ=="
         },
         "@ledgerhq/hw-transport": {
-          "version": "5.51.1",
-          "resolved": "https://registry.npmjs.org/@ledgerhq/hw-transport/-/hw-transport-5.51.1.tgz",
-          "integrity": "sha512-6wDYdbWrw9VwHIcoDnqWBaDFyviyjZWv6H9vz9Vyhe4Qd7TIFmbTl/eWs6hZvtZBza9K8y7zD8ChHwRI4s9tSw==",
+          "version": "6.31.3",
+          "resolved": "https://registry.npmjs.org/@ledgerhq/hw-transport/-/hw-transport-6.31.3.tgz",
+          "integrity": "sha512-rFplkHWF5NXtlYwAusqLlMu298NHtRD+2q/jrTYc//uu/xJO9LkDIgKid6IVF2+e1Wj7yX6YQVrU6L0Yu1ntEw==",
           "requires": {
-            "@ledgerhq/devices": "^5.51.1",
-            "@ledgerhq/errors": "^5.50.0",
+            "@ledgerhq/devices": "^8.4.3",
+            "@ledgerhq/errors": "^6.19.0",
+            "@ledgerhq/logs": "^6.12.0",
             "events": "^3.3.0"
           }
         },
-        "@ledgerhq/logs": {
-          "version": "5.50.0",
-          "resolved": "https://registry.npmjs.org/@ledgerhq/logs/-/logs-5.50.0.tgz",
-          "integrity": "sha512-swKHYCOZUGyVt4ge0u8a7AwNcA//h4nx5wIi0sruGye1IJ5Cva0GyK9L2/WdX+kWVTKp92ZiEo1df31lrWGPgA=="
+        "rxjs": {
+          "version": "7.8.1",
+          "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.1.tgz",
+          "integrity": "sha512-AA3TVj+0A2iuIoQkWEK/tqFjBq2j+6PO6Y0zJcvzLAFhEFIO3HL0vls9hWLncZbAAbK0mar7oZ4V079I/qPMxg==",
+          "requires": {
+            "tslib": "^2.1.0"
+          }
+        },
+        "tslib": {
+          "version": "2.7.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.7.0.tgz",
+          "integrity": "sha512-gLXCKdN1/j47AiHiOkJN69hJmcbGTHI0ImLmbYLHykhgeN0jVGola9yVjFgzCUklsZQMW55o+dW7IXv3RCXDzA=="
         }
       }
     },
     "@ledgerhq/hw-transport-webhid": {
-      "version": "6.27.15",
-      "resolved": "https://registry.npmjs.org/@ledgerhq/hw-transport-webhid/-/hw-transport-webhid-6.27.15.tgz",
-      "integrity": "sha512-xhtFy/SNttvBna8t1ZiP74K6Lj8uDhp0W+Zjvwz4IS6tS9gWZbKUB7scbrNrJep6Q77Of1bzDXrswyaoxFZrUg==",
+      "version": "6.28.6",
+      "resolved": "https://registry.npmjs.org/@ledgerhq/hw-transport-webhid/-/hw-transport-webhid-6.28.6.tgz",
+      "integrity": "sha512-npU1mgL97KovpTUgcdORoOZ7eVFgwCA7zt0MpgUGUMRNJWDgCFsJslx7KrVXlCGOg87gLfDojreIre502I5pYg==",
       "requires": {
-        "@ledgerhq/devices": "^8.0.3",
-        "@ledgerhq/errors": "^6.12.6",
-        "@ledgerhq/hw-transport": "^6.28.4",
-        "@ledgerhq/logs": "^6.10.1"
+        "@ledgerhq/devices": "^8.3.0",
+        "@ledgerhq/errors": "^6.16.4",
+        "@ledgerhq/hw-transport": "^6.30.6",
+        "@ledgerhq/logs": "^6.12.0"
+      },
+      "dependencies": {
+        "@ledgerhq/devices": {
+          "version": "8.4.3",
+          "resolved": "https://registry.npmjs.org/@ledgerhq/devices/-/devices-8.4.3.tgz",
+          "integrity": "sha512-+ih+M27E6cm6DHrmw3GbS3mEaznCyFc0e62VdQux40XK2psgYhL2yBPftM4KCrBYm1UbHqXzqLN+Jb7rNIzsHg==",
+          "requires": {
+            "@ledgerhq/errors": "^6.19.0",
+            "@ledgerhq/logs": "^6.12.0",
+            "rxjs": "^7.8.1",
+            "semver": "^7.3.5"
+          }
+        },
+        "@ledgerhq/errors": {
+          "version": "6.19.0",
+          "resolved": "https://registry.npmjs.org/@ledgerhq/errors/-/errors-6.19.0.tgz",
+          "integrity": "sha512-c3Jid7euMSnpHFp8H7iPtsmKDjwbTjlG46YKdw+RpCclsqtBx1uQDlYmcbP1Yv9201kVlUFUhhP4H623k8xzlQ=="
+        },
+        "@ledgerhq/hw-transport": {
+          "version": "6.31.3",
+          "resolved": "https://registry.npmjs.org/@ledgerhq/hw-transport/-/hw-transport-6.31.3.tgz",
+          "integrity": "sha512-rFplkHWF5NXtlYwAusqLlMu298NHtRD+2q/jrTYc//uu/xJO9LkDIgKid6IVF2+e1Wj7yX6YQVrU6L0Yu1ntEw==",
+          "requires": {
+            "@ledgerhq/devices": "^8.4.3",
+            "@ledgerhq/errors": "^6.19.0",
+            "@ledgerhq/logs": "^6.12.0",
+            "events": "^3.3.0"
+          }
+        },
+        "rxjs": {
+          "version": "7.8.1",
+          "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.1.tgz",
+          "integrity": "sha512-AA3TVj+0A2iuIoQkWEK/tqFjBq2j+6PO6Y0zJcvzLAFhEFIO3HL0vls9hWLncZbAAbK0mar7oZ4V079I/qPMxg==",
+          "requires": {
+            "tslib": "^2.1.0"
+          }
+        },
+        "tslib": {
+          "version": "2.7.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.7.0.tgz",
+          "integrity": "sha512-gLXCKdN1/j47AiHiOkJN69hJmcbGTHI0ImLmbYLHykhgeN0jVGola9yVjFgzCUklsZQMW55o+dW7IXv3RCXDzA=="
+        }
       }
     },
     "@ledgerhq/hw-transport-webusb": {
-      "version": "6.27.15",
-      "resolved": "https://registry.npmjs.org/@ledgerhq/hw-transport-webusb/-/hw-transport-webusb-6.27.15.tgz",
-      "integrity": "sha512-XRteQmJMFbMETOwwwJrXhEvBEdu1DpuDQNI04bzMQE9p81rLjwd6pIhfP/W1O94av7Iq4kaatNsNpxkitmp59w==",
+      "version": "6.28.6",
+      "resolved": "https://registry.npmjs.org/@ledgerhq/hw-transport-webusb/-/hw-transport-webusb-6.28.6.tgz",
+      "integrity": "sha512-rzICsvhcFcL4wSAvRPe+b9EEWB8cxj6yWy3FZdfs7ufi/0muNpFXWckWv1TC34em55sGXu2cMcwMKXg/O/Lc0Q==",
       "requires": {
-        "@ledgerhq/devices": "^8.0.3",
-        "@ledgerhq/errors": "^6.12.6",
-        "@ledgerhq/hw-transport": "^6.28.4",
-        "@ledgerhq/logs": "^6.10.1"
+        "@ledgerhq/devices": "^8.3.0",
+        "@ledgerhq/errors": "^6.16.4",
+        "@ledgerhq/hw-transport": "^6.30.6",
+        "@ledgerhq/logs": "^6.12.0"
+      },
+      "dependencies": {
+        "@ledgerhq/devices": {
+          "version": "8.4.3",
+          "resolved": "https://registry.npmjs.org/@ledgerhq/devices/-/devices-8.4.3.tgz",
+          "integrity": "sha512-+ih+M27E6cm6DHrmw3GbS3mEaznCyFc0e62VdQux40XK2psgYhL2yBPftM4KCrBYm1UbHqXzqLN+Jb7rNIzsHg==",
+          "requires": {
+            "@ledgerhq/errors": "^6.19.0",
+            "@ledgerhq/logs": "^6.12.0",
+            "rxjs": "^7.8.1",
+            "semver": "^7.3.5"
+          }
+        },
+        "@ledgerhq/errors": {
+          "version": "6.19.0",
+          "resolved": "https://registry.npmjs.org/@ledgerhq/errors/-/errors-6.19.0.tgz",
+          "integrity": "sha512-c3Jid7euMSnpHFp8H7iPtsmKDjwbTjlG46YKdw+RpCclsqtBx1uQDlYmcbP1Yv9201kVlUFUhhP4H623k8xzlQ=="
+        },
+        "@ledgerhq/hw-transport": {
+          "version": "6.31.3",
+          "resolved": "https://registry.npmjs.org/@ledgerhq/hw-transport/-/hw-transport-6.31.3.tgz",
+          "integrity": "sha512-rFplkHWF5NXtlYwAusqLlMu298NHtRD+2q/jrTYc//uu/xJO9LkDIgKid6IVF2+e1Wj7yX6YQVrU6L0Yu1ntEw==",
+          "requires": {
+            "@ledgerhq/devices": "^8.4.3",
+            "@ledgerhq/errors": "^6.19.0",
+            "@ledgerhq/logs": "^6.12.0",
+            "events": "^3.3.0"
+          }
+        },
+        "rxjs": {
+          "version": "7.8.1",
+          "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.1.tgz",
+          "integrity": "sha512-AA3TVj+0A2iuIoQkWEK/tqFjBq2j+6PO6Y0zJcvzLAFhEFIO3HL0vls9hWLncZbAAbK0mar7oZ4V079I/qPMxg==",
+          "requires": {
+            "tslib": "^2.1.0"
+          }
+        },
+        "tslib": {
+          "version": "2.7.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.7.0.tgz",
+          "integrity": "sha512-gLXCKdN1/j47AiHiOkJN69hJmcbGTHI0ImLmbYLHykhgeN0jVGola9yVjFgzCUklsZQMW55o+dW7IXv3RCXDzA=="
+        }
       }
     },
     "@ledgerhq/logs": {
@@ -5244,16 +5463,16 @@
       "requires": {}
     },
     "@multiversx/sdk-hw-provider": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/@multiversx/sdk-hw-provider/-/sdk-hw-provider-6.1.0.tgz",
-      "integrity": "sha512-9iQ2k6y80/OJ+30ETPNpN5t+pgI1mbBGGN60xaB7yH9E6eIlJuwZi/XIApMHKmitMdu7pe4+6Ig9FQHQ6YMxGA==",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@multiversx/sdk-hw-provider/-/sdk-hw-provider-7.0.0.tgz",
+      "integrity": "sha512-ZRGp5q985v5wvjnSZw+uvEXKGwe5YORuULhYMVoh63cPtGhyHIxl7H9D190KtSV0/LJfTcVUDDrtKoepOoKuVA==",
       "requires": {
         "@ledgerhq/devices": "8.0.3",
         "@ledgerhq/errors": "6.12.6",
-        "@ledgerhq/hw-transport": "6.28.4",
-        "@ledgerhq/hw-transport-u2f": "5.36.0-deprecated",
-        "@ledgerhq/hw-transport-webhid": "6.27.15",
-        "@ledgerhq/hw-transport-webusb": "6.27.15",
+        "@ledgerhq/hw-transport": "6.28.8",
+        "@ledgerhq/hw-transport-web-ble": "6.28.6",
+        "@ledgerhq/hw-transport-webhid": "6.28.6",
+        "@ledgerhq/hw-transport-webusb": "6.28.6",
         "buffer": "6.0.3",
         "platform": "1.3.6"
       }
@@ -7514,14 +7733,6 @@
       "integrity": "sha512-lcHwpNoggQTObv5apGNCTdJrO69eHOZMi4BNC+rTLER8iHAqGrUVeLh/irVIM7zTw2bOXA8T6uNPeujwOLg/2Q==",
       "peer": true
     },
-    "lru-cache": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-      "requires": {
-        "yallist": "^4.0.0"
-      }
-    },
     "md5.js": {
       "version": "1.3.5",
       "resolved": "https://registry.npmjs.org/md5.js/-/md5.js-1.3.5.tgz",
@@ -8121,12 +8332,9 @@
       "integrity": "sha512-1CdSqHQowJBnMAFyPEBRfqag/YP9OF394FV+4YREIJX4ljD7OxvQRDayyoyyCk+senRjSkP6VnUNQmVQqB6g7w=="
     },
     "semver": {
-      "version": "7.5.3",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.3.tgz",
-      "integrity": "sha512-QBlUtyVk/5EeHbi7X0fw6liDZc7BBmEaSYn01fMU1OUYbf6GPsbTtd8WmnqbI20SeycoHSeiybkE/q1Q+qlThQ==",
-      "requires": {
-        "lru-cache": "^6.0.0"
-      }
+      "version": "7.6.3",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
+      "integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A=="
     },
     "serialize-javascript": {
       "version": "6.0.2",
@@ -8381,11 +8589,6 @@
       "integrity": "sha512-C0WQT0gezHuw6AdY1M2jxUO83Rjf0HP7Sk1DtXj6j1EwkQNZrHAg2XPWlq62oqEhYvONq5pkC2Y9oPljWToLmQ==",
       "dev": true
     },
-    "u2f-api": {
-      "version": "0.2.7",
-      "resolved": "https://registry.npmjs.org/u2f-api/-/u2f-api-0.2.7.tgz",
-      "integrity": "sha512-fqLNg8vpvLOD5J/z4B6wpPg4Lvowz1nJ9xdHcCzdUPKcFE/qNCceV2gNZxSJd5vhAZemHr/K/hbzVA0zxB5mkg=="
-    },
     "ufo": {
       "version": "1.5.4",
       "resolved": "https://registry.npmjs.org/ufo/-/ufo-1.5.4.tgz",
@@ -8639,11 +8842,6 @@
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.3.tgz",
       "integrity": "sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ=="
-    },
-    "yallist": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     },
     "yargs": {
       "version": "15.4.1",

--- a/signing-providers/package.json
+++ b/signing-providers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "examples",
-  "version": "0.0.0",
+  "version": "0.0.1",
   "description": "Examples",
   "main": "src/index.js",
   "scripts": {
@@ -11,7 +11,7 @@
     "@multiversx/sdk-core": "13.5.0",
     "@multiversx/sdk-dapp-utils": "0.1.0",
     "@multiversx/sdk-extension-provider": "3.0.0",
-    "@multiversx/sdk-hw-provider": "6.1.0",
+    "@multiversx/sdk-hw-provider": "7.0.0",
     "@multiversx/sdk-native-auth-client": "1.0.9",
     "@multiversx/sdk-network-providers": "2.7.1",
     "@multiversx/sdk-wallet": "4.5.1",

--- a/signing-providers/src/config.devnet.js
+++ b/signing-providers/src/config.devnet.js
@@ -1,0 +1,11 @@
+import { WALLET_PROVIDER_DEVNET } from "@multiversx/sdk-web-wallet-provider";
+
+export const CHAIN_ID = "D";
+export const NETWORK_NAME = "Devnet";
+export const XALIAS_URL = "https://devnet.xalias.com";
+export const WALLET_PROVIDER_URL = WALLET_PROVIDER_DEVNET;
+export const API_URL = "https://devnet-api.multiversx.com";
+
+// Generate your own WalletConnect 2 ProjectId here: https://cloud.walletconnect.com/app
+export const WALLET_CONNECT_PROJECT_ID = "9b1a9564f91cb659ffe21b73d5c4e2d8";
+export const WALLET_CONNECT_RELAY_URL = "wss://relay.walletconnect.com";


### PR DESCRIPTION
Use cross-window web wallet connection to provide guardian signatures for guarded ledger account transactions.
Reason is that URL is limited to a number of characters while post-message communication removes this limit.

Main changes are replacing
`await this.walletProvider.guardTransactions(signedTransactions, { callbackUrl: getCurrentLocation() });`

with

` const guardedTransactions = await crossWindowProvider.guardTransactions(transactions);`